### PR TITLE
Fixed BUILD_NODE_EXTENSION macro redefinition

### DIFF
--- a/sleep.cc
+++ b/sleep.cc
@@ -1,5 +1,7 @@
 
+#ifndef BUILDING_NODE_EXTENSION
 #define BUILDING_NODE_EXTENSION
+#endif // BUILDING_NODE_EXTENSION
 
 #include <v8.h>
 #include <node.h>


### PR DESCRIPTION
Building on Mac OSX 10.7.5 was giving the following warning:

```
../sleep.cc:2:9: warning: 'BUILDING_NODE_EXTENSION' macro redefined
#define BUILDING_NODE_EXTENSION
        ^
<command line>:4:9: note: previous definition is here
#define BUILDING_NODE_EXTENSION 1
        ^
1 warning generated.
```

This change fixes it. 
