### PR TITLE
Bugfix npm warn about "repositories" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name":        "sleep",
-  "version":     "1.1.2",
+  "version":     "1.1.3",
   "main":        "./lib/index.js",
   "description": "Add sleep() and usleep() to nodejs",
   "homepage":    "http://github.com/ErikDubbelboer/node-sleep",
@@ -10,6 +10,10 @@
     "sleep",
     "usleep"
   ],
+  "repository": {
+    "type": "git",
+    "url":  "https://github.com/ErikDubbelboer/node-sleep.git"
+  },
   "repositories": [
     {
       "type": "git",


### PR DESCRIPTION
npm sends these warnings about the _repositories_ field :

```
npm WARN package.json sleep@1.1.2 'repositories' (plural) Not supported.
npm WARN package.json Please pick one as the 'repository' field
```

As I don't know if the _repositories_ field is needed for other purposes, I prefer adding a new **repository** field.

Feel free to delete the plural form if not needed.
