### PR TITLE
Require nan < 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url":  "https://github.com/ErikDubbelboer/node-sleep.git"
   },
   "dependencies": {
-    "nan": "*"
+    "nan": "<2.0.0"
   },
   "gypfile": true
 }


### PR DESCRIPTION
NAN 2.0.0 was just released and the whole API changed (see [CHANGELOG](https://github.com/nodejs/nan/blob/master/CHANGELOG.md)).

For now we should just require a version lower than 2.0.0.
But `node-sleep` should also be re-written to match the new API.