### PR TITLE
Print fallback warning to stderr rather than stdout

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 try {
   module.exports = require('./build/Release/node_sleep.node');
 } catch (e) {
-  console.log('sleep: using busy loop fallback');
+  console.error('sleep: using busy loop fallback');
 
   module.exports = {
     sleep: function(s) {


### PR DESCRIPTION
This would help people (like me :-) ) who are consuming CLIs built on top of this module ensure this warning goes into the right place and not mixed in with data…

Thanks!