### PR TITLE
cli: provide a simple cli, in order to have easy sleep on win

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Usage
 * `sleep.sleep(n)`: sleep for `n` seconds
 * `sleep.usleep(n)`: sleep for `n` microseconds (1 second is 1000000 microseconds)
 
+You can also install this as global dependency:
+
+    npm install -g
+    sleep 1
+    usleep 1000
+
+On unices or when you have already installed `sleep` and `usleep`, this
+installation will not override those. You can instead then use the CLI by
+running `sleepuv 1` and `usleepuv 1000`.
+
 
 [1]: http://linux.die.net/man/3/sleep
 [2]: http://linux.die.net/man/3/usleep

--- a/bin/sleep
+++ b/bin/sleep
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+'use strict'
+const parse = require('path').parse
+const sleep = require('../');
+
+const command = parse(process.argv[1]).name
+const argLen = process.argv.length
+
+if (argLen === 1 || argLen > 2) {
+  console.log('usage: sleep seconds')
+}
+
+if (isNaN(process.argv[2])) {
+  return
+}
+
+const n = parseInt(process.argv[2])
+
+// install as sleep and usleep, only if not found on system, else fall back
+// to sleepuv and usleepuv, if really wanted to use this implementation
+switch (command) {
+  case 'sleep':
+    sleep.sleep(n)
+    break;
+  case 'sleepuv':
+    sleep.sleep(n)
+    break;
+  case 'usleep':
+    sleep.usleep(n)
+    break;
+  case 'usleepuv':
+    sleep.usleep(n)
+    break;
+}

--- a/package.json
+++ b/package.json
@@ -18,5 +18,11 @@
   "dependencies": {
     "nan": ">=2.0.0"
   },
+  "bin": {
+    "sleep": "./bin/sleep",
+    "sleepuv": "./bin/sleep",
+    "usleep": "./bin/sleep",
+    "usleepuv": "./bin/sleep"
+  },
   "gypfile": true
 }


### PR DESCRIPTION
I am working on making nodejs/node core development easier on windows (even though I am not a windows guy). Anyhow, to run tests you'll need `cat`, `grep`, `curl`, `sleep` etc. in order to run tests. Installing binaries for them is quite the overhead and so I was hoping you provide a CLI for this. I am already working on the rest of the above list.

I checked install on unix and apparently it does not override installed unix binaries.

Would that be something for this repo? 

Reference for building node on windows is here:
https://github.com/nodejs/node/wiki/installation#building-on-windows