### PR TITLE
msleep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 sleep
 =====
 
-Add [`sleep()`][1] and [`usleep()`][2] to Node.js, via a C++ binding.
+Add [`sleep()`][1], `msleep()` and [`usleep()`][2] to Node.js, via a C++ binding.
 
 This is mainly useful for debugging.
 
@@ -13,6 +13,7 @@ Usage
     var sleep = require('sleep');
 
 * `sleep.sleep(n)`: sleep for `n` seconds
+* `sleep.msleep(n)`: sleep for `n` miliseconds
 * `sleep.usleep(n)`: sleep for `n` microseconds (1 second is 1000000 microseconds)
 
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,11 @@
+var sleep = require('./build/Release/node_sleep.node');
 
-module.exports = require('./build/Release/node_sleep.node');
+sleep.msleep = function(miliseconds) {
+  if (miliseconds < 1 || miliseconds % 1 != 0) {
+    throw new Exception('Expected number of miliseconds');
+  }
+  sleep.usleep(miliseconds * 1000);
+}
+
+module.exports = sleep;
 

--- a/test.js
+++ b/test.js
@@ -56,3 +56,25 @@ describe('usleep', function () {
     });
   });
 });
+
+describe('msleep', function () {
+  it('works for normal input', function() {
+    var sleepTime = 1;
+    var start = new Date();
+    sleep.msleep(sleepTime);
+    var end = new Date();
+    assertApproxEqual(end - start, sleepTime);
+  });
+
+  it('does not allow negative numbers', function () {
+    assert.throws(function () {
+      sleep.msleep(-100);
+    });
+  });
+
+  it('does not allow decimal numbers', function () {
+    assert.throws(function () {
+      sleep.msleep(1.5);
+    });
+  });
+});


### PR DESCRIPTION
Thanks for this module.

As you know, to wait for half a second you have to use `usleep(500000)`. This isn't terribly handy. How many zeroes are here, is it half a second or five seconds? While it may be natural for C++ programmers I bet the `msleep(500)` would be expected by most Javascript developers.