### PR TITLE
Updated the nan package version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/erikdubbelboer/node-sleep.git"
   },
   "dependencies": {
-    "nan": ">=2.0.0"
+    "nan": ">=2.5.1"
   },
   "devDependencies": {
     "mocha": "^3.0.2"


### PR DESCRIPTION
Using the older 2.0.0 version resulted in the following error when performing an npm install (on Node.js 6.9.1):

> ../../nan/nan.h: In function ‘bool Nan::SetAccessor(v8::Local<v8::Object>, v8::Local<v8::String>, Nan::GetterCallback, Nan::SetterCallback, v8::Local<v8::Value>, v8::AccessControl, v8::PropertyAttribute)’:
> ../../nan/nan.h:1933:16: warning: ‘bool v8::Object::SetAccessor(v8::Local<v8::Name>, v8::AccessorNameGetterCallback, v8::AccessorNameSetterCallback, v8::Local<v8::Value>, v8::AccessControl, v8::PropertyAttribute)’ is deprecated (declared at /home/weblogic/.node-gyp/6.9.1/include/node/v8.h:2750): Use maybe version [-Wdeprecated-declarations]
>      , attribute);
